### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/GregLewy/ab8067ac-0ff2-4484-8d81-aa4cd7edb869/6a849956-be54-4b9c-bd23-32b2834e907c/_apis/work/boardbadge/a0c898bb-b366-4435-8ca6-b098da602294)](https://dev.azure.com/GregLewy/ab8067ac-0ff2-4484-8d81-aa4cd7edb869/_boards/board/t/6a849956-be54-4b9c-bd23-32b2834e907c/Microsoft.RequirementCategory)
 # Tic Tac Toe Game
 
 Learn GitHub Actions through a fun little game.


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/GregLewy/ab8067ac-0ff2-4484-8d81-aa4cd7edb869/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.